### PR TITLE
Update metalworking.json to add bronze chisel

### DIFF
--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -136,6 +136,17 @@
     "melee_damage": { "bash": 4, "cut": 2 }
   },
   {
+    "id": "chisel_bronze",
+    "type": "TOOL",
+    "copy-from": "chisel",
+    "name": { "str": "bronze chisel" },
+    "description": "A short, stout metalworking chisel made of bronze.  It's used in some metalworking fabrication recipes.  Bronze chisels spark less than their steel counterparts, but are less durable.",
+    "weight": "735 g",
+    "price": 2000,
+    "material": [ "bronze" ],
+    "qualities": [ [ "CHISEL", 2 ], [ "CHISEL_WOOD", 2 ] ]
+  }
+  {
     "id": "crucible",
     "type": "TOOL",
     "name": { "str": "crucible" },


### PR DESCRIPTION

#### Purpose of change

With the addition of bronze metalworking tools, steel chisels were the only option for making bronze items, i have added bronze chisels as an option for the greek at heart. Bronze chisels have chiseling quality 2 and wood chiseling quality 2, so they cannot be used to make steel items. They cannot be used on most bronze items either yet, but future PRs will adjust some recipes that require chiseling to allow the bronze chisel to perform its intended function. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I anticipate a debate on whether or not it should have chiseling 3 or chiseling 2. It is possible to chisel hot steel with bronze tools, but not all the recipes which require chiseling 3 are "hot" recipes, and not everyone wants bronze tools to work on steel projects. Bronze projects are easier to chisel as a matter of fact, and there are several recipes, like chipping rocks, which do not necessarily require steel. We may want to make the bronze chisel chiselling 3 later, but for now it would make sense to reduce the chiseling quality required for the aforementioned projects and make the bronze chisel quality 2 so that the relative effectiveness of the bronze chisel is more closely aligned with its reason for being added and to satisfy the most verisimilitude.(It should AT LEAST be useful for bronze working but MAYBE NOT for steelworking. It can be upgraded later but in the meantime I can lower chiseling requirements for some recipes.) 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
added bronze chisel to game, used it to make zinc

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It has wood chiseling quality 2 so that it cannot make hygrometers, which are the only item that uses wood chiseling 3, and as i understand it actually require a chisel to be used on the steel components. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
